### PR TITLE
Replace Deprecated usages + Added Image-pipeline

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/AnimalsClassification.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/AnimalsClassification.java
@@ -9,12 +9,14 @@ import org.datavec.image.loader.NativeImageLoader;
 import org.datavec.image.recordreader.ImageRecordReader;
 import org.datavec.image.transform.FlipImageTransform;
 import org.datavec.image.transform.ImageTransform;
+import org.datavec.image.transform.PipelineImageTransform;
 import org.datavec.image.transform.WarpImageTransform;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
-import org.deeplearning4j.datasets.iterator.MultipleEpochsIterator;
 import org.deeplearning4j.eval.Evaluation;
-import org.deeplearning4j.nn.conf.*;
+import org.deeplearning4j.nn.conf.GradientNormalization;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
 import org.deeplearning4j.nn.conf.distribution.GaussianDistribution;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
@@ -23,7 +25,6 @@ import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
 import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
-import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
 import org.deeplearning4j.ui.api.UIServer;
 import org.deeplearning4j.ui.stats.StatsListener;
@@ -36,13 +37,14 @@ import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;
 import org.nd4j.linalg.learning.config.Nesterovs;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.schedule.ScheduleType;
 import org.nd4j.linalg.schedule.StepSchedule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
@@ -113,8 +115,14 @@ public class AnimalsClassification {
         ImageTransform flipTransform2 = new FlipImageTransform(new Random(123));
         ImageTransform warpTransform = new WarpImageTransform(rng, 42);
 //        ImageTransform colorTransform = new ColorConversionTransform(new Random(seed), COLOR_BGR2YCrCb);
-        List<ImageTransform> transforms = Arrays.asList(new ImageTransform[]{flipTransform1, warpTransform, flipTransform2});
+//        List<ImageTransform> transforms = Arrays.asList(new ImageTransform[]{flipTransform1, warpTransform, flipTransform2});
+        boolean shuffle = false;
+        List<Pair<ImageTransform,Double>> pipeline = new LinkedList<>();
+        pipeline.add(new Pair<>(flipTransform1,0.9));
+        pipeline.add(new Pair<>(flipTransform2,0.8));
+        pipeline.add(new Pair<>(warpTransform,0.5));
 
+        ImageTransform transform = new PipelineImageTransform(pipeline,shuffle);
         /**
          * Data Setup -> normalization
          *  - how to normalize images and generate large dataset to train on
@@ -154,7 +162,7 @@ public class AnimalsClassification {
          **/
         ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
         DataSetIterator dataIter;
-        MultipleEpochsIterator trainIter;
+//        MultipleEpochsIterator trainIter;
 
 
         log.info("Train model....");
@@ -163,11 +171,16 @@ public class AnimalsClassification {
         dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numLabels);
         scaler.fit(dataIter);
         dataIter.setPreProcessor(scaler);
-        trainIter = new MultipleEpochsIterator(epochs, dataIter);
-        network.fit(trainIter);
+   //     trainIter = new MultipleEpochsIterator(epochs, dataIter);
+        network.fit(trainIter,epochs);
 
         // Train with transformations
-        for (ImageTransform transform : transforms) {
+        recordReader.initialize(trainData,transform);
+        dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numLabels);
+        scaler.fit(dataIter);
+        dataIter.setPreProcessor(scaler);
+        network.fit(dataIter,epochs);
+       /* for (ImageTransform transform : transforms) {
             System.out.print("\nTraining on transformation: " + transform.getClass().toString() + "\n\n");
             recordReader.initialize(trainData, transform);
             dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numLabels);
@@ -175,7 +188,7 @@ public class AnimalsClassification {
             dataIter.setPreProcessor(scaler);
             trainIter = new MultipleEpochsIterator(epochs, dataIter);
             network.fit(trainIter);
-        }
+        }*/
 
         log.info("Evaluate model....");
         recordReader.initialize(testData);


### PR DESCRIPTION
"Fix for deprecated usage -> MultipleEpochsIterator + Image Pipeline replacing the loop"

## What changes were proposed in this pull request?

Replaced deprecated usages of MultipleEpochsIterator with MultiLayerNetwork.fit() 
Replaced looping through image transforms with an image pipeline. 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Tested manually.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
